### PR TITLE
Scene Graph Refactor and Collision that prevents placement of tiles.

### DIFF
--- a/core/controller/level/SceneGraphController.cs
+++ b/core/controller/level/SceneGraphController.cs
@@ -21,10 +21,12 @@ namespace WorldWizards.core.controller.level
             return sceneGraph.SceneSize();
         }
 
-        public void Add(WWObject wwObject)
+        public bool Add(WWObject wwObject)
         {
             if (wwObject != null)
-                sceneGraph.Add(wwObject);
+                return sceneGraph.Add(wwObject);
+            
+            return false;
         }
 
         public void Delete(Guid id)

--- a/core/entity/common/IntVector3.cs
+++ b/core/entity/common/IntVector3.cs
@@ -42,5 +42,14 @@ namespace WorldWizards.core.entity.common
             var other = (IntVector3) obj;
             return x == other.x && y == other.y && z == other.z;
         }
+
+        /// <summary>
+        /// from https://stackoverflow.com/questions/2634690/good-hash-function-for-a-2d-index
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return ((199 + x.GetHashCode()) * 199 + y.GetHashCode()) * 199 + z.GetHashCode();
+        }
     }
 }

--- a/core/entity/coordinate/Coordinate.cs
+++ b/core/entity/coordinate/Coordinate.cs
@@ -35,5 +35,6 @@ namespace WorldWizards.core.entity.coordinate
         public IntVector3 index { get; set; }
         public Vector3 offset { get; set; } // normalizedOffset [0,1]
         public int rotation { get; set; } // y rotation
+        
     }
 }

--- a/core/entity/coordinate/Coordinate.cs
+++ b/core/entity/coordinate/Coordinate.cs
@@ -35,6 +35,5 @@ namespace WorldWizards.core.entity.coordinate
         public IntVector3 index { get; set; }
         public Vector3 offset { get; set; } // normalizedOffset [0,1]
         public int rotation { get; set; } // y rotation
-        
     }
 }

--- a/core/entity/coordinate/utils/CoordinateHelper.cs
+++ b/core/entity/coordinate/utils/CoordinateHelper.cs
@@ -10,7 +10,7 @@ namespace WorldWizards.core.entity.coordinate.utils
 	public static class CoordinateHelper
     {
         public static float baseTileLength = 10; // the base size of what a tile should be
-        public static float tileLengthScale = .25f; // how much to scale up the base size
+        public static float tileLengthScale = 1f; // how much to scale up the base size
 
 	    /// <summary>
 	    ///     Gets the tile scale. Takes into account original scale of tiles.

--- a/core/entity/gameObject/WWObjectData.cs
+++ b/core/entity/gameObject/WWObjectData.cs
@@ -33,18 +33,18 @@ namespace WorldWizards.core.entity.gameObject
             children = new List<WWObjectData>();
         }
 
-        public Guid id { get; }
+        public Guid id { get; private set; }
 
         //		public WWType type { get; }
         //		public MetaData metaData { get;}
 
-        public Coordinate coordinate { get; }
+        public Coordinate coordinate { get; private set; }
 
         public WWObjectData parent { get; set; }
-        public List<WWObjectData> children { get; }
+        public List<WWObjectData> children { get; private set; }
 
 
-        public string resourceTag { get; }
+        public string resourceTag { get; private set; }
 
 
         public void AddChildren(List<WWObject> children)

--- a/core/entity/gameObject/resource/WWResource.cs
+++ b/core/entity/gameObject/resource/WWResource.cs
@@ -21,8 +21,8 @@ namespace WorldWizards.core.entity.gameObject.resource
             this.path = path;
         }
 
-        public string assetBundleTag { get; }
-        public string path { get; }
+        public string assetBundleTag { get; private set; }
+        public string path { get; private set; }
 
         public GameObject GetPrefab()
         {

--- a/core/entity/gameObject/resource/WWResourceMetaData.cs
+++ b/core/entity/gameObject/resource/WWResourceMetaData.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEngine;
 using WorldWizards.core.entity.common;
+using WorldWizards.core.entity.coordinate;
+using UnityEngine.Assertions;
+
 
 namespace WorldWizards.core.entity.gameObject.resource
 {
@@ -25,13 +28,24 @@ namespace WorldWizards.core.entity.gameObject.resource
             bottom = false;
             type = WWType.Tile;
         }
+        
+        public WWResourceMetaData(bool north, bool east, bool south, bool west, bool top, bool bottom, WWType type)
+        {
+            this.north = north;
+            this.east = east;
+            this.south = south;
+            this.west = west;
+            this.top = top;
+            this.bottom = bottom;
+            this.type = type;
+        }
 
         /// <summary>
         ///     Serializable boolean values are used to make editing metadata in the inspector easier, but they must be converted
         ///     to the enum bitflag for use.
         /// </summary>
         /// <returns>WWWalls equivalent to the serializable boolean values set in the inspector.</returns>
-        private WWWalls GetWallsEnum()
+        public WWWalls GetWallsEnum()
         {
             WWWalls result = 0;
 
@@ -50,12 +64,5 @@ namespace WorldWizards.core.entity.gameObject.resource
 
             return result;
         }
-        //        }
-        //            type = this.type;
-        //            wallBarriers = GetWallsEnum();
-        //        {
-
-
-        //        public void GetData(ref WWWalls wallBarriers, ref WWType type)
     }
 }

--- a/core/entity/gameObject/utils.meta
+++ b/core/entity/gameObject/utils.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d75d6687a4441148da0f7690476acbd
+timeCreated: 1509331941

--- a/core/entity/gameObject/utils/WWWallsHelper.cs
+++ b/core/entity/gameObject/utils/WWWallsHelper.cs
@@ -1,0 +1,63 @@
+﻿using UnityEngine;
+using UnityEngine.Assertions;
+using WorldWizards.core.entity.coordinate;
+using WorldWizards.core.entity.gameObject.resource;
+
+namespace WorldWizards.core.entity.gameObject.utils
+{
+    public class WWWallsHelper
+    {
+   
+        public static WWWalls getRotatedWWWalls(WWResourceMetaData metaData, Coordinate coordinate)
+        {
+            int yRotation = (coordinate.rotation % 360) + (coordinate.rotation < 0 ? 360 : 0);
+            
+            // rotation should only be 1 of 4 discrete values, 0, 90, 180, and 270
+            Debug.Log(yRotation);
+            Assert.IsTrue(yRotation == 0 || yRotation == 90 || yRotation == 180 || yRotation == 270 || yRotation == 360);
+
+            bool north;
+            bool east;
+            bool south;
+            bool west;
+            
+            if (yRotation == 0 || yRotation == 360)
+            {
+                north = metaData.north;
+                east = metaData.east;
+                south = metaData.south;
+                west = metaData.west;
+            }
+            else if (yRotation == 90)
+            {
+                north = metaData.west;
+                east = metaData.north;
+                south = metaData.east;
+                west = metaData.south;
+            }
+            else if (yRotation == 180)
+            {
+                north = metaData.south;
+                east = metaData.west;
+                south = metaData.north;
+                west = metaData.east;
+            }
+            else // (yRotation == 270)
+            {
+                north = metaData.east;
+                east = metaData.south;
+                south = metaData.west;
+                west = metaData.north;
+            }
+
+            bool t = metaData.top;
+            bool b = metaData.bottom;
+            
+            var rotatedMeteData  = new WWResourceMetaData(north,east,south,west,t,b, metaData.type);
+
+            var walls = rotatedMeteData.GetWallsEnum();
+            
+            return walls;
+        }
+    }
+}

--- a/core/entity/gameObject/utils/WWWallsHelper.cs
+++ b/core/entity/gameObject/utils/WWWallsHelper.cs
@@ -7,20 +7,20 @@ namespace WorldWizards.core.entity.gameObject.utils
 {
     public class WWWallsHelper
     {
-   
         public static WWWalls getRotatedWWWalls(WWResourceMetaData metaData, Coordinate coordinate)
         {
-            int yRotation = (coordinate.rotation % 360) + (coordinate.rotation < 0 ? 360 : 0);
-            
+            var yRotation = coordinate.rotation % 360 + (coordinate.rotation < 0 ? 360 : 0);
+
             // rotation should only be 1 of 4 discrete values, 0, 90, 180, and 270
             Debug.Log(yRotation);
-            Assert.IsTrue(yRotation == 0 || yRotation == 90 || yRotation == 180 || yRotation == 270 || yRotation == 360);
+            Assert.IsTrue(yRotation == 0 || yRotation == 90 || yRotation == 180 || yRotation == 270 ||
+                          yRotation == 360);
 
             bool north;
             bool east;
             bool south;
             bool west;
-            
+
             if (yRotation == 0 || yRotation == 360)
             {
                 north = metaData.north;
@@ -50,13 +50,13 @@ namespace WorldWizards.core.entity.gameObject.utils
                 west = metaData.north;
             }
 
-            bool t = metaData.top;
-            bool b = metaData.bottom;
-            
-            var rotatedMeteData  = new WWResourceMetaData(north,east,south,west,t,b, metaData.type);
+            var t = metaData.top;
+            var b = metaData.bottom;
 
-            var walls = rotatedMeteData.GetWallsEnum();
-            
+            var rotatedMetaData = new WWResourceMetaData(north, east, south, west, t, b, metaData.type);
+
+            var walls = rotatedMetaData.GetWallsEnum();
+
             return walls;
         }
     }

--- a/core/entity/gameObject/utils/WWWallsHelper.cs.meta
+++ b/core/entity/gameObject/utils/WWWallsHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 86bf9919b25f4386957d1de81520e42d
+timeCreated: 1509331933

--- a/core/entity/level/SceneDictionary.cs
+++ b/core/entity/level/SceneDictionary.cs
@@ -1,0 +1,127 @@
+﻿using WorldWizards.core.entity.coordinate;
+using WorldWizards.core.entity.gameObject;
+using System.Collections.Generic;
+using System;
+using UnityEngine.Assertions;
+using UnityEngine;
+
+namespace WorldWizards.core.entity.level
+{
+    public class SceneDictionary
+    {
+        private readonly Dictionary<Coordinate, List<Guid>> coordinates;
+        private readonly Dictionary<Guid, WWObject> objects;
+
+        public SceneDictionary()
+        {
+            objects = new Dictionary<Guid, WWObject>();
+            coordinates = new Dictionary<Coordinate, List<Guid>>();
+        }
+
+        public List<WWObjectDataMemento> GetMementoObjects()
+        {
+            var objectstoSave = new List<WWObjectDataMemento>();
+            Debug.Log(GetCount());
+            foreach (var entry in objects)
+            {
+                var memento = new WWObjectDataMemento(entry.Value.objectData);
+                objectstoSave.Add(memento);
+            }
+            return objectstoSave;
+        }
+        
+        
+        public List<WWObject> GetObjectsInCoordinateIndex(Coordinate coordinate)
+        {
+            var guids = coordinates[coordinate];
+            
+            var result = new List<WWObject>();
+
+            foreach (var guid in guids)
+            {
+                result.Add(objects[guid]);
+            }
+            return result;            
+        }
+
+        public bool ContainsGuid(Guid id)
+        {
+            return objects.ContainsKey(id);
+        }
+
+        public int GetCount()
+        {
+            return objects.Count;
+        }
+
+        public void Add(WWObject wwObject)
+        {
+            var coord = wwObject.GetCoordinate();
+            var guid = wwObject.GetId();
+            
+            Assert.IsNotNull(coord);
+            
+            if (coordinates.ContainsKey(coord))
+            {
+                coordinates[coord].Add(guid);
+            }
+            else
+            {
+                var guidList = new List<Guid>();
+                guidList.Add(guid);
+                coordinates.Add(coord, guidList);
+            }
+            objects.Add(wwObject.GetId(), wwObject);
+        }
+
+
+        public List<Guid> GetAllGuids()
+        {
+            return new List<Guid>(objects.Keys);
+        }
+
+        public WWObject Remove(Guid id)
+        {
+            WWObject removedObject;
+            objects.TryGetValue(id, out removedObject);
+            if (removedObject)
+            {
+                objects.Remove(id);
+                // now we have to remove the the id from the coordinate to List<Guid> Dictionary
+                
+                foreach (var kvp in coordinates)
+                {
+                    if (kvp.Value.Contains(id))
+                    {
+                        kvp.Value.Remove(id);
+                    }
+                }
+            }
+            return removedObject;
+        }
+        
+        public WWObject Get(Guid id)
+        {
+            WWObject objectToGet;
+            objects.TryGetValue(id, out objectToGet);
+            if (!objectToGet) Debug.LogError("SceneGraph : Failed to get Object with Guid " + id);
+            return objectToGet;
+        }
+
+        public List<WWObject> Get(Coordinate coord)
+        {
+            var result = new List<WWObject>();
+            if (coordinates.ContainsKey(coord))
+            {
+                var guids = coordinates[coord];
+                foreach (var guid in guids)
+                {
+                    result.Add(objects[guid]);
+                }
+            }
+            return result;
+        }
+
+        
+    }
+}

--- a/core/entity/level/SceneDictionary.cs
+++ b/core/entity/level/SceneDictionary.cs
@@ -1,11 +1,9 @@
-﻿using WorldWizards.core.entity.coordinate;
-using WorldWizards.core.entity.gameObject;
+﻿using System;
 using System.Collections.Generic;
-using System;
 using UnityEngine;
-using UnityEngine.Assertions;
 using WorldWizards.core.entity.common;
-using WorldWizards.core.entity.gameObject.resource;
+using WorldWizards.core.entity.coordinate;
+using WorldWizards.core.entity.gameObject;
 using WorldWizards.core.entity.gameObject.utils;
 
 namespace WorldWizards.core.entity.level
@@ -32,19 +30,17 @@ namespace WorldWizards.core.entity.level
             }
             return objectstoSave;
         }
-        
-        
+
+
         public List<WWObject> GetObjectsInCoordinateIndex(Coordinate coordinate)
         {
             var guids = coordinates[coordinate.index];
-            
+
             var result = new List<WWObject>();
 
             foreach (var guid in guids)
-            {
                 result.Add(objects[guid]);
-            }
-            return result;            
+            return result;
         }
 
         public bool ContainsGuid(Guid id)
@@ -64,13 +60,11 @@ namespace WorldWizards.core.entity.level
                 var objectsAtCoord = Get(wwObject.GetCoordinate());
                 WWWalls existingWalls = 0;
                 foreach (var obj in objectsAtCoord)
-                {
                     if (obj.resourceMetaData.type.Equals(WWType.Tile))
                     {
                         var walls = WWWallsHelper.getRotatedWWWalls(obj.resourceMetaData, obj.GetCoordinate());
                         existingWalls = existingWalls | walls;
                     }
-                }
                 var newWalls = WWWallsHelper.getRotatedWWWalls(wwObject.resourceMetaData, wwObject.GetCoordinate());
                 var doesCollide = Convert.ToBoolean(newWalls & existingWalls); // should be 0 or False if no collision
                 return doesCollide;
@@ -89,17 +83,17 @@ namespace WorldWizards.core.entity.level
                 return false;
             }
             if (coordinates.ContainsKey(coord.index))
-                {
-                    Debug.Log("Updating Guid list.");
-                    coordinates[coord.index].Add(guid);
-                }
-                else
-                {
-                    Debug.Log("Creating new Guid list.");
-                    var guidList = new List<Guid>();
-                    guidList.Add(guid);
-                    coordinates.Add(coord.index, guidList);
-                }
+            {
+                Debug.Log("Updating Guid list.");
+                coordinates[coord.index].Add(guid);
+            }
+            else
+            {
+                Debug.Log("Creating new Guid list.");
+                var guidList = new List<Guid>();
+                guidList.Add(guid);
+                coordinates.Add(coord.index, guidList);
+            }
             objects.Add(wwObject.GetId(), wwObject);
             return true;
         }
@@ -118,18 +112,14 @@ namespace WorldWizards.core.entity.level
             {
                 objects.Remove(id);
                 // now we have to remove the the id from the coordinate to List<Guid> Dictionary
-                
+
                 foreach (var kvp in coordinates)
-                {
                     if (kvp.Value.Contains(id))
-                    {
                         kvp.Value.Remove(id);
-                    }
-                }
             }
             return removedObject;
         }
-        
+
         public WWObject Get(Guid id)
         {
             WWObject objectToGet;
@@ -145,13 +135,9 @@ namespace WorldWizards.core.entity.level
             {
                 var guids = coordinates[coord.index];
                 foreach (var guid in guids)
-                {
                     result.Add(objects[guid]);
-                }
             }
             return result;
         }
-
-        
     }
 }

--- a/core/entity/level/SceneDictionary.cs.meta
+++ b/core/entity/level/SceneDictionary.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fcf6d765bebb416f841c4fef89cc8444
+timeCreated: 1509302857

--- a/core/entity/level/SceneGraph.cs
+++ b/core/entity/level/SceneGraph.cs
@@ -50,9 +50,9 @@ namespace WorldWizards.core.entity.level
             return _sceneDictionary.GetObjectsInCoordinateIndex(coordinate);
         }
 
-        public void Add(WWObject worldWizardsObject)
+        public bool Add(WWObject worldWizardsObject)
         {
-           _sceneDictionary.Add(worldWizardsObject);
+          return _sceneDictionary.Add(worldWizardsObject);
         }
 
 	    /// <summary>
@@ -65,14 +65,6 @@ namespace WorldWizards.core.entity.level
 
             return _sceneDictionary.Remove(id);
         }
-
-        //		public void Delete(Guid id){
-        //			// check if id exists in the sceneGraph
-        //			if (objects.ContainsKey (id)) {
-        //				WWObject objectToDestroy = Remove (id);
-        //				Destroy (objectToDestroy);
-        //			}
-        //		}
 
         private void Destroy(WWObject objectToDestroy)
         {

--- a/core/entity/level/SceneGraph.cs
+++ b/core/entity/level/SceneGraph.cs
@@ -6,14 +6,15 @@ using WorldWizards.core.controller.level.utils;
 using WorldWizards.core.entity.coordinate;
 using WorldWizards.core.entity.coordinate.utils;
 using WorldWizards.core.entity.gameObject;
+using Object = UnityEngine.Object;
 
 namespace WorldWizards.core.entity.level
 {
-	/// <summary>
-	///     The Scene Graph is the data structure that holds all the World
-	///     Wizards Objects in the current level.
-	/// </summary>
-	public class SceneGraph
+    /// <summary>
+    ///     The Scene Graph is the data structure that holds all the World
+    ///     Wizards Objects in the current level.
+    /// </summary>
+    public class SceneGraph
     {
         private readonly SceneDictionary _sceneDictionary;
 
@@ -22,60 +23,59 @@ namespace WorldWizards.core.entity.level
             _sceneDictionary = new SceneDictionary();
         }
 
-	    /// <summary>
-	    ///     Determine how many WWObjects are in the scene graph
-	    /// </summary>
-	    /// <returns>The number if WWObjects in the scene graph.</returns>
-	    public int SceneSize()
-	    {
-	        return _sceneDictionary.GetCount();
-	    }
+        /// <summary>
+        ///     Determine how many WWObjects are in the scene graph
+        /// </summary>
+        /// <returns>The number if WWObjects in the scene graph.</returns>
+        public int SceneSize()
+        {
+            return _sceneDictionary.GetCount();
+        }
 
-	    /// <summary>
-	    ///     Clears all the objects in the scene graph.
-	    /// </summary>
-	    public void ClearAll()
+        /// <summary>
+        ///     Clears all the objects in the scene graph.
+        /// </summary>
+        public void ClearAll()
         {
             var keys = _sceneDictionary.GetAllGuids();
             foreach (var key in keys) Delete(key);
         }
 
-	    /// <summary>
-	    ///     Gets the objects in the SceneGraph in the given coordinate index space.
-	    /// </summary>
-	    /// <returns>the objects in the SceneGraph in the given coordinate index space.</returns>
-	    /// <param name="coordinate">The coordinate to space to get.</param>
-	    public List<WWObject> GetObjectsInCoordinateIndex(Coordinate coordinate)
+        /// <summary>
+        ///     Gets the objects in the SceneGraph in the given coordinate index space.
+        /// </summary>
+        /// <returns>the objects in the SceneGraph in the given coordinate index space.</returns>
+        /// <param name="coordinate">The coordinate to space to get.</param>
+        public List<WWObject> GetObjectsInCoordinateIndex(Coordinate coordinate)
         {
             return _sceneDictionary.GetObjectsInCoordinateIndex(coordinate);
         }
 
         public bool Add(WWObject worldWizardsObject)
         {
-          return _sceneDictionary.Add(worldWizardsObject);
+            return _sceneDictionary.Add(worldWizardsObject);
         }
 
-	    /// <summary>
-	    ///     Remove an object from the scene graph.
-	    /// </summary>
-	    /// <param name="id"></param>
-	    /// <returns>returns removed object, which may be null.</returns>
-	    private WWObject Remove(Guid id)
+        /// <summary>
+        ///     Remove an object from the scene graph.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>returns removed object, which may be null.</returns>
+        private WWObject Remove(Guid id)
         {
-
             return _sceneDictionary.Remove(id);
         }
 
         private void Destroy(WWObject objectToDestroy)
         {
 #if UNITY_EDITOR
-            UnityEngine.Object.DestroyImmediate(objectToDestroy.gameObject);
+            Object.DestroyImmediate(objectToDestroy.gameObject);
 #else
 			GameObject.Destroy (objectToDestroy.gameObject);
 			#endif
         }
 
-        
+
         public void Delete(Guid id)
         {
             if (_sceneDictionary.ContainsGuid(id))

--- a/core/entity/level/SceneGraph.cs
+++ b/core/entity/level/SceneGraph.cs
@@ -6,7 +6,6 @@ using WorldWizards.core.controller.level.utils;
 using WorldWizards.core.entity.coordinate;
 using WorldWizards.core.entity.coordinate.utils;
 using WorldWizards.core.entity.gameObject;
-using Object = UnityEngine.Object;
 
 namespace WorldWizards.core.entity.level
 {
@@ -16,12 +15,11 @@ namespace WorldWizards.core.entity.level
 	/// </summary>
 	public class SceneGraph
     {
-        private readonly Dictionary<Guid, WWObject> objects;
-
+        private readonly SceneDictionary _sceneDictionary;
 
         public SceneGraph()
         {
-            objects = new Dictionary<Guid, WWObject>();
+            _sceneDictionary = new SceneDictionary();
         }
 
 	    /// <summary>
@@ -29,16 +27,16 @@ namespace WorldWizards.core.entity.level
 	    /// </summary>
 	    /// <returns>The number if WWObjects in the scene graph.</returns>
 	    public int SceneSize()
-        {
-            return objects.Count;
-        }
+	    {
+	        return _sceneDictionary.GetCount();
+	    }
 
 	    /// <summary>
 	    ///     Clears all the objects in the scene graph.
 	    /// </summary>
 	    public void ClearAll()
         {
-            var keys = new List<Guid>(objects.Keys);
+            var keys = _sceneDictionary.GetAllGuids();
             foreach (var key in keys) Delete(key);
         }
 
@@ -49,21 +47,12 @@ namespace WorldWizards.core.entity.level
 	    /// <param name="coordinate">The coordinate to space to get.</param>
 	    public List<WWObject> GetObjectsInCoordinateIndex(Coordinate coordinate)
         {
-            var result = new List<WWObject>();
-            foreach (var wwObject in objects.Values)
-                if (coordinate.index.Equals(wwObject.GetCoordinate().index)) result.Add(wwObject);
-            return result;
+            return _sceneDictionary.GetObjectsInCoordinateIndex(coordinate);
         }
 
         public void Add(WWObject worldWizardsObject)
         {
-            //			List<WWObject> collidingObjects =  GetObjectsInCoordinateIndex (worldWizardsObject.objectData.coordinate);
-            //			if (collidingObjects.Count == 0) {
-            //				objects.Add (worldWizardsObject.GetId (), worldWizardsObject);
-            //			} else {
-            //				Destroy (worldWizardsObject);
-            //			}
-            objects.Add(worldWizardsObject.GetId(), worldWizardsObject);
+           _sceneDictionary.Add(worldWizardsObject);
         }
 
 	    /// <summary>
@@ -73,10 +62,8 @@ namespace WorldWizards.core.entity.level
 	    /// <returns>returns removed object, which may be null.</returns>
 	    private WWObject Remove(Guid id)
         {
-            WWObject removedObject;
-            objects.TryGetValue(id, out removedObject);
-            if (removedObject) objects.Remove(id);
-            return removedObject;
+
+            return _sceneDictionary.Remove(id);
         }
 
         //		public void Delete(Guid id){
@@ -90,16 +77,16 @@ namespace WorldWizards.core.entity.level
         private void Destroy(WWObject objectToDestroy)
         {
 #if UNITY_EDITOR
-            Object.DestroyImmediate(objectToDestroy.gameObject);
+            UnityEngine.Object.DestroyImmediate(objectToDestroy.gameObject);
 #else
 			GameObject.Destroy (objectToDestroy.gameObject);
 			#endif
         }
 
-
+        
         public void Delete(Guid id)
         {
-            if (objects.ContainsKey(id))
+            if (_sceneDictionary.ContainsGuid(id))
             {
                 var rootObject = Get(id);
 
@@ -124,60 +111,14 @@ namespace WorldWizards.core.entity.level
 
         public WWObject Get(Guid id)
         {
-            WWObject objectToGet;
-            objects.TryGetValue(id, out objectToGet);
-            if (!objectToGet) Debug.LogError("SceneGraph : Failed to get Object with Guid " + id);
-            return objectToGet;
+            return _sceneDictionary.Get(id);
         }
 
 
-        //        public List<WWObject> GetAllOfType(WWType type)
-        //        {
-        //            return null;
-        //        }
-        //
-        //        public List<WWObject> GetAllOfMetaData(MetaData metaData)
-        //        {
-        //            return null;
-        //        }
-        //
-        //        public List<WWObject> GetAdjacentTiles(List<Guid> selection)
-        //        {
-        //            return null;
-        //        }
-        //
-        //        public List<WWObject> GetPropsContainedInTiles(List<Guid> selection)
-        //        {
-        //            return null;
-        //        }
-
-        //        public WWObject GetRootParent(List<Guid> selection)
-        //        {
-        //            return null;
-        //        }
-
-        //        public List<WWObject> GetAllChildren(List<Guid> selection)
-        //        {
-        //            return null;
-        //        }
-
-        //        // TODO: Does it return itself? or just its siblings?
-        //        public List<WWObject> GetAllSiblings(List<Guid> selection)
-        //        {
-        //            return null;
-        //        }
-
         public void Save()
         {
-            var objectstoSave = new List<WWObjectDataMemento>();
-            Debug.Log(objects.Count);
-            foreach (var entry in objects)
-            {
-                var memento = new WWObjectDataMemento(entry.Value.objectData);
-                objectstoSave.Add(memento);
-            }
-
-            var json = JsonConvert.SerializeObject(objectstoSave);
+            var objectsToSave = _sceneDictionary.GetMementoObjects();
+            var json = JsonConvert.SerializeObject(objectsToSave);
             FileIO.SaveJSONToFile(json, FileIO.testPath);
         }
 
@@ -203,9 +144,7 @@ namespace WorldWizards.core.entity.level
                 foreach (var childID in obj.children)
                 {
                     var childObject = Get(childID);
-                    //					if (childObject) { // TODO remove the null check by ensuring no dangling children
                     childrenToRestore.Add(childObject);
-                    //					}
                 }
                 root.AddChildren(childrenToRestore);
             }

--- a/core/experimental/CreateObjectGun.cs
+++ b/core/experimental/CreateObjectGun.cs
@@ -33,6 +33,9 @@ namespace WorldWizards.core.experimental
 
             possibleTiles = WWResourceController.GetResourceKeysByAssetBundle("ww_basic_assets");
             Debug.Log(possibleTiles.Count);
+            
+            gridCollider.transform.localScale = Vector3.one * CoordinateHelper.tileLengthScale;
+
         }
 
 
@@ -55,9 +58,9 @@ namespace WorldWizards.core.experimental
             {
                 var position = raycastHit.point;
                 // because the tile center is in the middle need to offset
-                position.x += .5f * CoordinateHelper.baseTileLength;
-                position.y += CoordinateHelper.baseTileLength;
-                position.z += .5f * CoordinateHelper.baseTileLength;
+                position.x += .5f * CoordinateHelper.baseTileLength * CoordinateHelper.tileLengthScale;
+                position.y += CoordinateHelper.baseTileLength * CoordinateHelper.tileLengthScale;
+                position.z += .5f * CoordinateHelper.baseTileLength * CoordinateHelper.tileLengthScale;
                 CycleObjectsScrollWheel(position);
                 RotateObjects(position);
                 coordDebugText.text = string.Format("x : {0}, z : {1}", position.x, position.z);
@@ -65,7 +68,7 @@ namespace WorldWizards.core.experimental
                 if (curObject == null) curObject = PlaceObject(position);
                 else
                     curObject.transform.position = new Vector3(raycastHit.point.x,
-                        raycastHit.point.y + 0.5f * CoordinateHelper.baseTileLength,
+                        raycastHit.point.y + 0.5f * CoordinateHelper.baseTileLength * CoordinateHelper.tileLengthScale,
                         raycastHit.point.z);
                 if (Input.GetMouseButtonUp(0))
                     if (curObject != null)

--- a/core/experimental/CreateObjectGun.cs
+++ b/core/experimental/CreateObjectGun.cs
@@ -75,8 +75,10 @@ namespace WorldWizards.core.experimental
                     {
                         Destroy(curObject.gameObject);
                         curObject = PlaceObject(position);
-                        sceneGraphController.Add(curObject);
-                        curObject = null;
+                        if (sceneGraphController.Add(curObject))
+                        {
+                            curObject = null;
+                        }
                     }
             }
         }


### PR DESCRIPTION
Changed the underlying data structure to a custom SceneDictionary so WWObjects are now indexed by both Coordinate and Guid. Constant lookup times for both.

Added collision detection that takes into account both the rotation and walls bit mask of the object to place as well as the walls bit mask of existing objects in the coordinate space when adding an object to the SceneGraph.